### PR TITLE
Update files on branch smartshift-smith-m-1687894703

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,8 @@
   "resolutions": {
     "@types/react": "18.0.5",
     "@types/react-dom": "18.0.1"
+  },
+  "dependencies": {
+    "react": "18"
   }
 }

--- a/packages/test-suite-vite/src/main.tsx
+++ b/packages/test-suite-vite/src/main.tsx
@@ -1,13 +1,14 @@
 import './index.css'
 
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 
 import App from './App'
 
-ReactDOM.render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
 	<React.StrictMode>
 		<App />
-	</React.StrictMode>,
-	document.getElementById('root'),
-)
+	</React.StrictMode>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -21104,6 +21104,7 @@ __metadata:
     inquirer: ^9.1.4
     markdown-spellcheck: ^1.3.1
     npm-run-all: ^4.1.5
+    react: 18
     react-dnd: "workspace:^"
     react-dnd-examples: "workspace:^"
     react-dnd-html5-backend: "workspace:^"
@@ -21497,7 +21498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.2.0, react@npm:^18.2.0":
+"react@npm:18, react@npm:18.2.0, react@npm:^18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
   dependencies:


### PR DESCRIPTION
Please review and merge these changes. 
 Explanations: migrations/test/react-dnd/react-dnd/packages/test-suite-vite/src/main.tsx:
The changes in this git diff are part of a migration task where ReactDOM.render is replaced with createRoot, a new API for rendering in React.

1. The import statement for ReactDOM has been replaced with an import statement for createRoot from 'react-dom/client'. This change is because we are no longer using the old ReactDOM.render method and instead we are using the new createRoot for rendering.

2. Instead of directly calling ReactDOM.render and passing the React element and the root DOM container as arguments, we first find the root DOM node with document.getElementById('root') and store it in the variable `container`.

3. Then, we create a root from the DOM container using the createRoot function and store it in the variable `root`.

4. Finally, we call the render method on the `root` object and pass the React element as the argument. This is equivalent to the previous ReactDOM.render call, but is using the new createRoot API. 

This change provides a way to opt into a concurrent mode where React will keep your app responsive while rendering complex component trees and handling intensive computations. It's a part of the ongoing React updates aiming to improve the performance and user experience of React apps.